### PR TITLE
Fixing Bugs for CedarCopilot installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13952,7 +13952,7 @@
 			}
 		},
 		"packages/cedar-os": {
-			"version": "0.0.1",
+			"version": "0.0.5",
 			"license": "ISC",
 			"dependencies": {
 				"@mastra/client-js": "^0.1.16",
@@ -13983,8 +13983,6 @@
 			"devDependencies": {
 				"@types/lodash": "^4.17.16",
 				"@types/node": "^20.17.19",
-				"@types/react": "^18.3.18",
-				"@types/react-dom": "^18.3.5",
 				"@types/uuid": "^10.0.0",
 				"autoprefixer": "^10.4.20",
 				"clsx": "^2.1.1",
@@ -13998,8 +13996,18 @@
 				"typescript": "^5.7.3"
 			},
 			"peerDependencies": {
-				"react": "^18.2.0",
-				"react-dom": "^18.2.0"
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^18 || ^19 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"packages/cedar-os/node_modules/fast-glob": {

--- a/packages/cedar-os-components/chatInput/ChatInput.tsx
+++ b/packages/cedar-os-components/chatInput/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useVoice, VoiceIndicator, cn } from 'cedar-os';
 
-import { EditorContent } from '@tiptap/react';
+import { CedarEditorContent as EditorContent } from 'cedar-os';
 import { Code, Image, Mic, SendHorizontal } from 'lucide-react';
 import { motion } from 'motion/react';
 import React, { useCallback, useEffect } from 'react';

--- a/packages/cedar-os-components/chatInput/ContextBadgeRow.tsx
+++ b/packages/cedar-os-components/chatInput/ContextBadgeRow.tsx
@@ -6,7 +6,7 @@ import {
 	withClassName,
 } from 'cedar-os';
 import { X } from 'lucide-react';
-import type { Editor } from '@tiptap/react';
+import type { CedarEditor as Editor } from 'cedar-os';
 
 interface ContextBadgeRowProps {
 	editor?: Editor | null;

--- a/packages/cedar-os/package.json
+++ b/packages/cedar-os/package.json
@@ -1,23 +1,37 @@
 {
 	"name": "cedar-os",
-	"version": "0.0.1",
+	"version": "0.0.7",
 	"description": "",
 	"sideEffects": false,
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"clean": "rm -rf dist && mkdir -p dist",
 		"build": "npm run clean && tsup ./src",
-		"p": "npm i && pnpm install && NODE_OPTIONS='--max-old-space-size=8192' pnpm run build && npm publish",
+		"p": "pnpm install && NODE_OPTIONS='--max-old-space-size=8192' pnpm run build && npm publish",
 		"dev": "npm run clean && tsup --watch",
 		"watch": "tsup ./src --watch",
 		"dev:yalc": "nodemon --watch 'src/**/*' -e ts,tsx --exec 'NODE_OPTIONS=\"--max-old-space-size=8192\" npm run build && yalc publish --push'"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/CedarCopilot/cedar-OS.git"
 	},
 	"keywords": [],
 	"author": "",
 	"license": "ISC",
 	"peerDependencies": {
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
+		"@types/react": "*",
+		"@types/react-dom": "*",
+		"react": "^18 || ^19 || ^19.0.0-rc",
+		"react-dom": "^18 || ^19 || ^19.0.0-rc"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		},
+		"@types/react-dom": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"@mastra/client-js": "^0.1.16",
@@ -48,8 +62,6 @@
 	"devDependencies": {
 		"@types/lodash": "^4.17.16",
 		"@types/node": "^20.17.19",
-		"@types/react": "^18.3.18",
-		"@types/react-dom": "^18.3.5",
 		"@types/uuid": "^10.0.0",
 		"autoprefixer": "^10.4.20",
 		"clsx": "^2.1.1",
@@ -61,6 +73,12 @@
 		"tailwindcss-animate": "^1.0.7",
 		"tsup": "^8.3.6",
 		"typescript": "^5.7.3"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/CedarCopilot/cedar-OS/issues"
 	},
 	"files": [
 		"dist",

--- a/packages/cedar-os/pnpm-lock.yaml
+++ b/packages/cedar-os/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
+      '@types/react':
+        specifier: '*'
+        version: 18.3.20
+      '@types/react-dom':
+        specifier: '*'
+        version: 18.3.7(@types/react@18.3.20)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -72,10 +78,10 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
-        specifier: ^18.2.0
+        specifier: ^18 || ^19 || ^19.0.0-rc
         version: 18.3.1
       react-dom:
-        specifier: ^18.2.0
+        specifier: ^18 || ^19 || ^19.0.0-rc
         version: 18.3.1(react@18.3.1)
       react-markdown:
         specifier: ^10.1.0
@@ -93,12 +99,6 @@ importers:
       '@types/node':
         specifier: ^20.17.19
         version: 20.17.32
-      '@types/react':
-        specifier: ^18.3.18
-        version: 18.3.20
-      '@types/react-dom':
-        specifier: ^18.3.5
-        version: 18.3.7(@types/react@18.3.20)
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0

--- a/packages/cedar-os/src/components/CedarCopilot.client.tsx
+++ b/packages/cedar-os/src/components/CedarCopilot.client.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useCedarStore } from '@/store/CedarStore';
+import type { ProviderConfig } from '@/store/agentConnection/types';
+
+export interface CedarCopilotProps {
+	children: React.ReactNode;
+	productId?: string | null;
+	userId?: string | null;
+	llmProvider?: ProviderConfig;
+}
+
+// Client-side component with useEffect
+export function CedarCopilotClient({
+	children,
+	userId = null,
+	llmProvider,
+}: CedarCopilotProps) {
+	const setProviderConfig = useCedarStore((state) => state.setProviderConfig);
+
+	useEffect(() => {
+		if (llmProvider) {
+			setProviderConfig(llmProvider);
+		}
+	}, [llmProvider, setProviderConfig]);
+
+	console.log('CedarCopilot', { userId, llmProvider });
+
+	return <>{children}</>;
+}

--- a/packages/cedar-os/src/components/CedarCopilot.tsx
+++ b/packages/cedar-os/src/components/CedarCopilot.tsx
@@ -1,31 +1,7 @@
-'use client';
+import React from 'react';
+import { CedarCopilotClient, CedarCopilotProps } from './CedarCopilot.client';
 
-import React, { useEffect } from 'react';
-import { useCedarStore } from '@/store/CedarStore';
-import type { ProviderConfig } from '@/store/agentConnection/types';
-
-export interface CedarCopilotProps {
-	children: React.ReactNode;
-	productId?: string | null;
-	userId?: string | null;
-	llmProvider?: ProviderConfig;
+// Server component wrapper so consumers can import CedarCopilot in Server Components
+export function CedarCopilot(props: CedarCopilotProps) {
+	return <CedarCopilotClient {...props} />;
 }
-
-// The main CedarCopilot component with Zustand store
-export const CedarCopilot: React.FC<CedarCopilotProps> = ({
-	children,
-	userId = null,
-	llmProvider,
-}) => {
-	const setProviderConfig = useCedarStore((state) => state.setProviderConfig);
-
-	useEffect(() => {
-		if (llmProvider) {
-			setProviderConfig(llmProvider);
-		}
-	}, [llmProvider, setProviderConfig]);
-
-	console.log('CedarCopilot', { userId, llmProvider });
-
-	return <>{children}</>;
-};

--- a/packages/cedar-os/src/index.ts
+++ b/packages/cedar-os/src/index.ts
@@ -127,3 +127,9 @@ export {
 	useStyling,
 	useVoice,
 } from '@/store/CedarStore';
+
+// Export Tiptap components
+export {
+	Editor as CedarEditor,
+	EditorContent as CedarEditorContent,
+} from '@tiptap/react';


### PR DESCRIPTION
- Fixing React Peer dependencies
- Wrapping CedarCopilot in a server component so client apps can use it in root layout / other server components
- Fixing package.json to include github repo link and bug link (github issues)
- Exporting tiptap components so consuming applications don't have to install tiptap/react